### PR TITLE
psm minOut validation

### DIFF
--- a/contracts/src/libs/Errors.sol
+++ b/contracts/src/libs/Errors.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 error NotAuthorized();
 error RouteHalted();
 error DepthExceeded();
+error InvalidParam();
 error CapExceeded();
 error ExceedsExitLiquidity();
 error StaleParity();

--- a/contracts/src/psm/PSM.sol
+++ b/contracts/src/psm/PSM.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {I0xUSD} from "../interfaces/I0xUSD.sol";
-import {NotAuthorized, RouteHalted, DepthExceeded, StaleParity} from "../libs/Errors.sol";
+import {NotAuthorized, RouteHalted, DepthExceeded, StaleParity, InvalidParam} from "../libs/Errors.sol";
 
 contract PSM {
     struct Route {
@@ -44,11 +44,11 @@ contract PSM {
         if (r.halted) revert RouteHalted();
         if (amount > r.maxDepth) revert DepthExceeded();
         // parity check placeholder
-        uint256 out = (amount * (10000 - r.spreadBps)) / 10000;
-        if (out < minOut) revert StaleParity();
+        uint256 outUsd = (amount * (10000 - r.spreadBps)) / 10000;
+        if (outUsd < minOut) revert InvalidParam();
         r.buffer += amount;
-        token.mint(msg.sender, out);
-        emit Swap(msg.sender, stable, amount, out);
+        token.mint(msg.sender, outUsd);
+        emit Swap(msg.sender, stable, amount, outUsd);
     }
 
     function swap0xUSDForStable(address stable, uint256 amount, uint256 minOut) external {

--- a/contracts/test/PSM.t.sol
+++ b/contracts/test/PSM.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import {Test} from "forge-std/Test.sol";
 import {PSM} from "../src/psm/PSM.sol";
 import {OxUSD} from "../src/token/0xUSD.sol";
+import {InvalidParam} from "../src/libs/Errors.sol";
 
 contract PSMTest is Test {
     PSM psm;
@@ -20,6 +21,11 @@ contract PSMTest is Test {
     function testSwapStableFor0xUSD() public {
         psm.swapStableFor0xUSD(stable, 100, 99);
         assertEq(token.balanceOf(address(this)), 100);
+    }
+
+    function testSwapStableFor0xUSDInvalidMinOut() public {
+        vm.expectRevert(InvalidParam.selector);
+        psm.swapStableFor0xUSD(stable, 100, 101);
     }
 
     function testHaltReverts() public {


### PR DESCRIPTION
## Summary
- guard against insufficient outputs in PSM swap
- cover swap when minOut exceeds output

## Testing
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc38c6ffd4832a86f57029eb7d5b10