### PR TITLE
Fix PSM sweep buffer accounting and add test

### DIFF
--- a/contracts/src/interfaces/IPSM.sol
+++ b/contracts/src/interfaces/IPSM.sol
@@ -4,4 +4,5 @@ pragma solidity ^0.8.24;
 interface IPSM {
     function swapStableFor0xUSD(address stable, uint256 amount, uint256 minOut) external;
     function swap0xUSDForStable(address stable, uint256 amount, uint256 minOut) external;
+    function sweep(address stable, address to, uint256 amt) external;
 }

--- a/contracts/src/psm/PSM.sol
+++ b/contracts/src/psm/PSM.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import {I0xUSD} from "../interfaces/I0xUSD.sol";
 import {NotAuthorized, RouteHalted, DepthExceeded, StaleParity} from "../libs/Errors.sol";
+import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
 
 contract PSM {
     struct Route {
@@ -60,5 +61,12 @@ contract PSM {
         r.buffer -= out;
         token.burn(msg.sender, amount);
         emit Swap(msg.sender, stable, amount, out);
+    }
+
+    function sweep(address stable, address to, uint256 amt) external onlyGuardian {
+        Route storage r = routes[stable];
+        if (amt > r.buffer) revert DepthExceeded();
+        r.buffer -= amt;
+        IERC20(stable).transfer(to, amt);
     }
 }

--- a/contracts/test/PSM.t.sol
+++ b/contracts/test/PSM.t.sol
@@ -5,26 +5,41 @@ import {Test} from "forge-std/Test.sol";
 import {PSM} from "../src/psm/PSM.sol";
 import {OxUSD} from "../src/token/0xUSD.sol";
 
+contract MockStable {
+    function transfer(address, uint256) external returns (bool) {
+        return true;
+    }
+}
+
 contract PSMTest is Test {
     PSM psm;
     OxUSD token;
-    address stable = address(0xdead);
+    MockStable stable;
 
     function setUp() public {
         token = new OxUSD();
         psm = new PSM(token, address(this));
         token.setMinters(address(psm), address(0));
-        psm.setRoute(stable, 0, type(uint256).max);
+        stable = new MockStable();
+        psm.setRoute(address(stable), 0, type(uint256).max);
     }
 
     function testSwapStableFor0xUSD() public {
-        psm.swapStableFor0xUSD(stable, 100, 99);
+        psm.swapStableFor0xUSD(address(stable), 100, 99);
         assertEq(token.balanceOf(address(this)), 100);
     }
 
     function testHaltReverts() public {
-        psm.halt(stable, true);
+        psm.halt(address(stable), true);
         vm.expectRevert();
-        psm.swapStableFor0xUSD(stable, 1, 0);
+        psm.swapStableFor0xUSD(address(stable), 1, 0);
+    }
+
+    function testSweepDecreasesBuffer() public {
+        psm.swapStableFor0xUSD(address(stable), 100, 99);
+        (uint256 beforeBuffer, , , ) = psm.routes(address(stable));
+        psm.sweep(address(stable), address(this), 40);
+        (uint256 afterBuffer, , , ) = psm.routes(address(stable));
+        assertEq(afterBuffer, beforeBuffer - 40);
     }
 }


### PR DESCRIPTION
## Summary
- update PSM sweep to check and deduct buffer before token transfer
- expose sweep in IPSM interface
- add unit test ensuring sweep reduces the route buffer

## Testing
- `forge test` *(fails: command not found)*
- `curl -L https://foundry.paradigm.xyz | bash` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc38cde4a8832ab37966c9f16b2bcf