### PR TITLE
test: expect revert when paused

### DIFF
--- a/contracts/test/Token.t.sol
+++ b/contracts/test/Token.t.sol
@@ -23,4 +23,11 @@ contract TokenTest is Test {
         token.burn(address(this), 50);
         assertEq(token.balanceOf(address(this)), 50);
     }
+
+    function testPauseBlocksTransfer() public {
+        token.mint(address(this), 100);
+        token.pause();
+        vm.expectRevert(OxUSD.Paused.selector);
+        token.transfer(address(1), 50);
+    }
 }


### PR DESCRIPTION
## Summary
- add test to ensure transfers revert when token is paused

## Testing
- `forge test` *(fails: command not found)*
- `curl -L https://foundry.paradigm.xyz | bash` *(fails: CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc30d825c4832ab1e0af61bde1b3b7