### PR TITLE
chore(ci): setup pnpm and solhint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,13 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
       - run: pnpm install --frozen-lockfile
         working-directory: sdk
-      - run: npx solhint 'contracts/**/*.sol'
+      - run: npm install -g solhint
+      - run: solhint 'contracts/**/*.sol'
       - run: pnpm lint
         working-directory: sdk
 
@@ -33,6 +37,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
       - run: pnpm install --frozen-lockfile
         working-directory: sdk
       - run: pnpm test


### PR DESCRIPTION
## Summary
- ensure pnpm is configured before executing pnpm commands in CI
- install solhint globally and run it during lint job

## Testing
- `npm install -g solhint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/solhint)*
- `npx solhint 'contracts/**/*.sol'` *(fails: 403 Forbidden - GET https://registry.npmjs.org/solhint)*
- `pnpm install --frozen-lockfile` *(fails: Cannot install with "frozen-lockfile" because pnpm-lock.yaml is absent)*
- `pnpm lint` *(fails: ESLint couldn't find a configuration file)*
- `pnpm test`
- `forge --version` *(fails: command not found)*
- `curl -L https://foundry.paradigm.xyz | bash` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc30e3c8c8832ab6bdd4649c8782d7