### PR TITLE
Precompute outUsd and test slippage reverts

### DIFF
--- a/contracts/src/psm/PSM.sol
+++ b/contracts/src/psm/PSM.sol
@@ -51,11 +51,10 @@ contract PSM {
         if (r.halted) revert RouteHalted();
         if (amount > r.maxDepth) revert DepthExceeded();
 
-        // scale STABLE (r.decimals) -> 18-decimals 0xUSD
+        // compute 0xUSD amount before any state changes
         uint256 scale = 10 ** (18 - r.decimals);
-        uint256 outUsd = (amount * scale * (10000 - r.spreadBps)) / 10000;
-
-        // keep InvalidParam for buy-side minOut failure
+        uint256 outUsd = amount * scale;
+        outUsd = (outUsd * (10000 - r.spreadBps)) / 10000;
         if (outUsd < minOut) revert InvalidParam();
 
         // Account STABLE received into buffer

--- a/contracts/test/PSM.t.sol
+++ b/contracts/test/PSM.t.sol
@@ -38,6 +38,12 @@ contract PSMTest is Test {
         assertEq(token.balanceOf(address(this)), 1e18);
     }
 
+    function testSwapStableFor0xUSD6DecimalsSlippageReverts() public {
+        psm.setRoute(stable6, 0, type(uint256).max, 6);
+        vm.expectRevert(InvalidParam.selector);
+        psm.swapStableFor0xUSD(stable6, 1e6, 1e18 + 1);
+    }
+
     function testSwap0xUSDForStable6Decimals() public {
         psm.setRoute(stable6, 0, type(uint256).max, 6);
         psm.swapStableFor0xUSD(stable6, 2e6, 0);          // buffer = 2e6


### PR DESCRIPTION
## Summary
- precompute outUsd before state updates and minting to enforce slippage bounds
- add test for 6-decimal route slippage failure

## Testing
- `forge test` *(fails: forge: command not found)*
- `curl -L https://foundry.paradigm.xyz | bash` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc533ac3ec832a9eb1890ec025129d