### PR TITLE
psm: track buffer on sweep

### DIFF
--- a/contracts/src/psm/PSM.sol
+++ b/contracts/src/psm/PSM.sol
@@ -89,8 +89,9 @@ contract PSM {
 
     function sweep(address stable, address to, uint256 amt) external onlyGuardian {
         Route storage r = routes[stable];
-        if (amt > r.buffer) revert DepthExceeded();
-        r.buffer -= amt;
+        uint256 buf = r.buffer;
+        if (amt > buf) revert DepthExceeded();
+        r.buffer = buf - amt;
         IERC20(stable).transfer(to, amt);
     }
 }

--- a/contracts/test/PSM.t.sol
+++ b/contracts/test/PSM.t.sol
@@ -64,12 +64,15 @@ contract PSMTest is Test {
         psm.sweep(stable, address(this), 1);
     }
 
-    function testSweepDecreasesBuffer() public {
-        psm.swapStableFor0xUSD(stable, 100, 99);
-        (uint256 beforeBuffer, , , , ) = psm.routes(stable);
+    function testSweepBufferAccounting() public {
+        psm.swapStableFor0xUSD(stable, 100, 99); // buffer = 100
         psm.sweep(stable, address(this), 40);
+
         (uint256 afterBuffer, , , , ) = psm.routes(stable);
-        assertEq(afterBuffer, beforeBuffer - 40);
+        assertEq(afterBuffer, 60);
+
+        vm.expectRevert(DepthExceeded.selector);
+        psm.sweep(stable, address(this), 61); // exceeds remaining buffer
     }
 
     function testSwap0xUSDForStable() public {


### PR DESCRIPTION
## Summary
- subtract amount from route buffer during sweep and revert if exceeding
- test sweep reduces buffer and prevents overdraw

## Testing
- `forge test` *(fails: command not found: forge)*

------
https://chatgpt.com/codex/tasks/task_e_68bc54b057a8832aa4af66985af2766a