### PR TITLE
Add zero address guards

### DIFF
--- a/contracts/src/governance/ParamRegistry.sol
+++ b/contracts/src/governance/ParamRegistry.sol
@@ -24,6 +24,7 @@ contract ParamRegistry {
     }
 
     function setSpread(address stable, uint256 bps) external onlyDao {
+        if (stable == address(0)) revert ZeroAddress();
         emit SpreadSet(stable, bps);
     }
 

--- a/contracts/src/savings/SavingsVault.sol
+++ b/contracts/src/savings/SavingsVault.sol
@@ -11,6 +11,7 @@ contract SavingsVault is ERC4626 {
     address public guardian;
 
     constructor(IERC20 asset, address _guardian) ERC20("s0xUSD", "s0xUSD") ERC4626(asset) {
+        if (_guardian == address(0)) revert ZeroAddress();
         guardian = _guardian;
     }
 

--- a/contracts/test/ParamRegistry.t.sol
+++ b/contracts/test/ParamRegistry.t.sol
@@ -23,4 +23,9 @@ contract ParamRegistryTest is Test {
         registry.setAddr(key, value);
         assertEq(registry.addrs(key), value);
     }
+
+    function testSetSpreadZeroAddressReverts() public {
+        vm.expectRevert(ZeroAddress.selector);
+        registry.setSpread(address(0), 100);
+    }
 }

--- a/contracts/test/SavingsVault.t.sol
+++ b/contracts/test/SavingsVault.t.sol
@@ -48,4 +48,9 @@ contract SavingsVaultTest is Test {
         vm.expectRevert(ZeroAddress.selector);
         vault.setVenue(address(0), true);
     }
+
+    function testConstructorZeroGuardianReverts() public {
+        vm.expectRevert(ZeroAddress.selector);
+        new SavingsVault(token, address(0));
+    }
 }


### PR DESCRIPTION
## Summary
- prevent zero guardian in `SavingsVault` constructor
- validate stable address in `ParamRegistry.setSpread`
- test zero-address guards for SavingsVault and ParamRegistry

## Testing
- `forge test -q` *(fails: command not found)*
- `curl -L https://foundry.paradigm.xyz | bash` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5840a0a0832aa98e6b5f03eedb59